### PR TITLE
Support for foreign keys with multiple columns

### DIFF
--- a/src/KitLoong/MigrationsGenerator/Generators/ForeignKeyGenerator.php
+++ b/src/KitLoong/MigrationsGenerator/Generators/ForeignKeyGenerator.php
@@ -35,8 +35,8 @@ class ForeignKeyGenerator
         foreach ($foreignKeys as $foreignKey) {
             $fields[] = [
                 'name' => $this->getName($foreignKey, $ignoreForeignKeyNames),
-                'field' => $foreignKey->getLocalColumns()[0],
-                'references' => $foreignKey->getForeignColumns()[0],
+                'field' => $foreignKey->getLocalColumns(),
+                'references' => $foreignKey->getForeignColumns(),
                 'on' => $this->decorator->tableWithoutPrefix($foreignKey->getForeignTableName()),
                 'onUpdate' => $foreignKey->hasOption('onUpdate') ? $foreignKey->getOption('onUpdate') : 'RESTRICT',
                 'onDelete' => $foreignKey->hasOption('onDelete') ? $foreignKey->getOption('onDelete') : 'RESTRICT',

--- a/src/Xethron/MigrationsGenerator/Syntax/AddForeignKeysToTable.php
+++ b/src/Xethron/MigrationsGenerator/Syntax/AddForeignKeysToTable.php
@@ -14,14 +14,23 @@ class AddForeignKeysToTable extends Table
      */
     protected function getItem(array $foreignKey): string
     {
-        $value = $foreignKey['field'];
-        if (!empty($foreignKey['name'])) {
-            $value .= "', '".$foreignKey['name'];
+        // Check for multiple columns
+        if (count($foreignKey['field']) > 1) {
+            $value = "['" . implode("', '", $foreignKey['field']) . "']";
+            $references = "['" . implode("', '", $foreignKey['references']) . "']";
+        } else {
+            $value = "'" . $foreignKey['field'][0] . "'";
+            $references = "'" . $foreignKey['references'][0] . "'";
         }
+
+        if (!empty($foreignKey['name'])) {
+            $value .= ", '" . $foreignKey['name'] . "'";
+        }
+
         $output = sprintf(
-            "\$table->foreign('%s')->references('%s')->on('%s')",
+            "\$table->foreign(%s)->references(%s)->on('%s')",
             $value,
-            $foreignKey['references'],
+            $references,
             $foreignKey['on']
         );
         if ($foreignKey['onUpdate']) {


### PR DESCRIPTION
I used your package back in April to generate Laravel migrations for a larger database structure and just found out today, that it falsely generated the foreign keys for foreign keys with multiple columns. 

Currently the migration gets generated with only the first column. That is incorrect and even more false than ignoring the whole foreign key, since it shifts the meaning and makes some operations impossible.

So I just thought I fix this. I hope it's useful. :) 