### PR TITLE
Update Doctrine DBAL to v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": ">=7.1.3",
 		"illuminate/support": "^5.6|^6.0|^7.0|^8.0",
-		"doctrine/dbal": "^3.0"
+		"doctrine/dbal": "~2.4|^3.0"
 	},
     "require-dev": {
         "orchestra/testbench": "^3.6|^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": ">=7.1.3",
 		"illuminate/support": "^5.6|^6.0|^7.0|^8.0",
-		"doctrine/dbal": "~2.4"
+		"doctrine/dbal": "^3.0"
 	},
     "require-dev": {
         "orchestra/testbench": "^3.6|^4.0|^5.0",


### PR DESCRIPTION
My current app already had doctrine/dbal version 3.0 installed and after attempting to install this package I ran into the following issue:

```
Loading composer repositories with package information
Updating dependencies (including require-dev)         
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for kitloong/laravel-migrations-generator dev-master -> satisfiable by kitloong/laravel-migrations-generator[dev-master].
    - Can only install one of: doctrine/dbal[3.0.0, 2.12.x-dev].
    - Can only install one of: doctrine/dbal[3.0.x-dev, 2.12.x-dev].
    - Can only install one of: doctrine/dbal[3.1.x-dev, 2.12.x-dev].
    - Conclusion: install doctrine/dbal 2.12.x-dev
    - Installation request for doctrine/dbal ^3.0 -> satisfiable by doctrine/dbal[3.0.0, 3.0.x-dev, 3.1.x-dev].
```

Everything seems to still work ok. Can his be updated?

Thank you!