### PR TITLE
Add possibility to specify the date used in the migration file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 1. Removed unused classes.
 1. Added UT!
 1. More UT will be added to increase coverage.
+1. It is now possible to specify the date used in the migration file name
 
 This package is clone from https://github.com/Xethron/migrations-generator and updated to support Laravel 6 and above.
 
@@ -87,6 +88,7 @@ Run `php artisan help migrate:generate` for a list of options.
 |-t, --tables[=TABLES]|A list of Tables you wish to Generate Migrations for separated by a comma: users,posts,comments|
 |-i, --ignore[=IGNORE]|A list of Tables you wish to ignore, separated by a comma: users,posts,comments|
 |-p, --path[=PATH]|Where should the file be created?|
+|-d, --date[=DATE]|The date used in the migration file name|
 |  --useDBCollation|Follow db collations for migrations|
 |  --defaultIndexNames|Don't use db index names for migrations|
 |  --defaultFKNames|Don't use db foreign key names for migrations|
@@ -103,6 +105,8 @@ Thanks to Jeffrey Way for his amazing Laravel-4-Generators package. This package
 Kit Loong
 
 Bernhard Breytenbach ([@BBreyten](https://twitter.com/BBreyten))
+
+Patrick Falize ([@defser](https://github.com/defser))
 
 ## License
 

--- a/src/KitLoong/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/KitLoong/MigrationsGenerator/MigrateGenerateCommand.php
@@ -25,6 +25,7 @@ class MigrateGenerateCommand extends GeneratorCommand
                 {--t|tables= : A list of Tables you wish to Generate Migrations for separated by a comma: users,posts,comments}
                 {--i|ignore= : A list of Tables you wish to ignore, separated by a comma: users,posts,comments}
                 {--p|path= : Where should the file be created?}
+                {--d|date=now : The date used in the file name}
                 {--tp|templatePath= : The location of the template for this generator}
                 {--useDBCollation : Follow db collations for migrations}
                 {--defaultIndexNames : Don\'t use db index names for migrations}
@@ -189,13 +190,13 @@ class MigrateGenerateCommand extends GeneratorCommand
     protected function generateMigrationFiles(array $tables): void
     {
         $this->info("Setting up Tables and Index Migrations");
-        $this->datePrefix = date('Y_m_d_His');
+        $this->datePrefix = date('Y_m_d_His', strtotime($this->option('date')));
         $this->generateTablesAndIndices($tables);
 
         $this->info("\nSetting up Foreign Key Migrations\n");
 
         // Plus 1 second to have foreign key migrations generate after table migrations generated
-        $this->datePrefix = date('Y_m_d_His', strtotime('+1 second'));
+        $this->datePrefix = date('Y_m_d_His', strtotime($this->option('date') . ' +1 second'));
         $this->generateForeignKeys($tables);
     }
 


### PR DESCRIPTION
Use option -d, --date[=DATE] to specify a date that will be used in the migration file name. 
Default will be "now" as expected and currently is.
When a date provided by the user cannot be parsed the default fallback returned by strtotime is "1970-01-01"