### PR TITLE
[bugfix] Postgres ignored tables do not contain " "

### DIFF
--- a/src/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/MigrationsGenerator/MigrateGenerateCommand.php
@@ -139,7 +139,10 @@ class MigrateGenerateCommand extends Command
             $tables = $this->schema->getTableNames();
         }
 
-        return array_diff($tables, $this->getExcludedTables());
+        return array_diff(
+            collect($this->getExcludedTables())->map(fn ($table) => '"'.$table.'"')->toArray(),
+            $this->getExcludedTables()
+        );
     }
 
     /**

--- a/src/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/MigrationsGenerator/MigrateGenerateCommand.php
@@ -132,9 +132,9 @@ class MigrateGenerateCommand extends Command
     protected function filterTables(): array
     {
         if ($tableArg = (string) $this->argument('tables')) {
-            $tables = explode(',', $tableArg);
+            $tables = collect(explode(',', $tableArg))->map(fn ($table) => '"'.$table.'"')->toArray();
         } elseif ($tableOpt = (string) $this->option('tables')) {
-            $tables = explode(',', $tableOpt);
+            $tables = collect(explode(',', $tableOpt))->map(fn ($table) => '"'.$table.'"')->toArray();
         } else {
             $tables = $this->schema->getTableNames();
         }


### PR DESCRIPTION
For some reason, when using the `--ignore` command in Postgres, the `$tables` in `filterTables()` look like this:

```php
array:2 [
  0 => ""Daily_Consumables""
  1 => ""Daily_Personnel""
]
```

This fixes it, but I assume it needs to have a check for Postgres, as currently, I'm unaware if this persists for other database connection drivers as well.