### PR TITLE
Use connection specified in Settings when fetching config())

### DIFF
--- a/src/MigrationsGenerator/DBAL/Support/FilterTables.php
+++ b/src/MigrationsGenerator/DBAL/Support/FilterTables.php
@@ -40,7 +40,7 @@ trait FilterTables
         }
 
         // Schema name defined in Laravel framework.
-        $schema = $this->setting->getConnection()->getConfig('schema');
+        $schema = app(MigrationsGeneratorSetting::class)->getConnection()->getConfig('schema');
 
         $parts     = explode('.', $table);
         $namespace = $parts[0];

--- a/src/MigrationsGenerator/DBAL/Support/FilterTables.php
+++ b/src/MigrationsGenerator/DBAL/Support/FilterTables.php
@@ -40,7 +40,7 @@ trait FilterTables
         }
 
         // Schema name defined in Laravel framework.
-        $schema = DB::connection()->getConfig('schema');
+        $schema = $this->setting->getConnection()->getConfig('schema');
 
         $parts     = explode('.', $table);
         $namespace = $parts[0];


### PR DESCRIPTION
This is a fix for #84 .  Config was being read for the default connection instead of the user specified connection