### PR TITLE
Fix view migrations not generated

### DIFF
--- a/src/DBAL/Models/PgSQL/PgSQLView.php
+++ b/src/DBAL/Models/PgSQL/PgSQLView.php
@@ -16,7 +16,9 @@ class PgSQLView extends DBALView
     {
         $this->createViewSQL = $this->makeCreateViewSQL($this->quotedName, $view->getSql());
 
-        if ($view->getNamespaceName() === DB::connection()->getConfig('schema')) {
+        $searchPath = DB::connection()->getConfig('search_path') ?: DB::connection()->getConfig('schema');
+
+        if ($view->getNamespaceName() === $searchPath) {
             // Strip namespace from name.
             $name                = $view->getShortestName($view->getNamespaceName());
             $this->name          = $this->makeName($name);

--- a/src/DBAL/PgSQLSchema.php
+++ b/src/DBAL/PgSQLSchema.php
@@ -28,12 +28,12 @@ class PgSQLSchema extends DBALSchema
                 }
 
                 // Schema name defined in the framework configuration.
-                $schema = DB::connection()->getConfig('schema');
+                $searchPath = DB::connection()->getConfig('search_path') ?: DB::connection()->getConfig('schema');
 
                 $parts     = explode('.', $table);
                 $namespace = $parts[0];
 
-                return $namespace === $schema;
+                return $namespace === $searchPath;
             })
             ->values();
     }
@@ -77,7 +77,7 @@ class PgSQLSchema extends DBALSchema
 
                 // Start from Laravel 9, the `schema` configuration option used to configure Postgres connection search paths renamed to `search_path`.
                 // Fallback to `schema` if Laravel version is older than 9.
-                $searchPath = DB::connection()->getConfig('search_path') ?? DB::connection()->getConfig('schema');
+                $searchPath = DB::connection()->getConfig('search_path') ?: DB::connection()->getConfig('schema');
 
                 return $view->getNamespaceName() === $searchPath;
             })

--- a/src/DBAL/PgSQLSchema.php
+++ b/src/DBAL/PgSQLSchema.php
@@ -75,7 +75,11 @@ class PgSQLSchema extends DBALSchema
                     return false;
                 }
 
-                return $view->getNamespaceName() === DB::connection()->getConfig('schema');
+                // Start from Laravel 9, the `schema` configuration option used to configure Postgres connection search paths renamed to `search_path`.
+                // Fallback to `schema` if Laravel version is older than 9.
+                $searchPath = DB::connection()->getConfig('search_path') ?? DB::connection()->getConfig('schema');
+
+                return $view->getNamespaceName() === $searchPath;
             })
             ->map(function (DoctrineDBALView $view) {
                 return new PgSQLView($view);

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -31,7 +31,6 @@ abstract class FeatureTestCase extends TestCase
         parent::setUp();
 
         $this->prepareStorage();
-        $this->dropAllTables();
     }
 
     protected function tearDown(): void

--- a/tests/Feature/SQLSrv/CommandTest.php
+++ b/tests/Feature/SQLSrv/CommandTest.php
@@ -125,7 +125,7 @@ class CommandTest extends SQLSrvTestCase
      * @param  callable  $generateMigrations
      * @throws \Doctrine\DBAL\Exception
      */
-    public function verify(callable $migrateTemplates, callable $generateMigrations)
+    private function verify(callable $migrateTemplates, callable $generateMigrations)
     {
         $migrateTemplates();
 


### PR DESCRIPTION
Start from Laravel 9, the `schema` configuration option used to configure Postgres connection search paths renamed to `search_path`.
https://laravel.com/docs/9.x/upgrade#postgres-schema-configuration