### PR TITLE
Task/laravel 9 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,41 @@ php artisan migrate:generate --connection="connection_name"
 
 ### Squash migrations
 
-By default, Generator will generate multiple migration files for each table. 
+By default, Generator will generate multiple migration files for each table.
 
 You can squash all migrations into a single file with:
 
 ```bash
 php artisan migrate:generate --squash
 ```
+
+
+### Migration templates (stub)
+
+You can publish the stubs, just run:
+
+```bash
+php artisan vendor:publish --provider="KitLoong\MigrationsGenerator\MigrationsGeneratorServiceProvider" --tag="templates"
+
+## To use a specific template runing:
+php artisan migrate:generate --template-path=resources/stub/anonymous-class-migration.stub
+```
+
+### Migration like Laravel 9+ (anonymous class)
+
+By default, Generator will generate all migrations using the template before Laravel 9.
+
+If you want to generate a Laravel 9+ migration version, just set the param `--anonymous` or `-A`.
+
+```bash
+php artisan migrate:generate --anonymous
+php artisan migrate:generate -A
+```
+
+> ! **Note**
+> `--template-path` take precedence hover `--anonymous`.
+> To use `--anonymous`, you can't  use `--tp|template-path`
+
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ php artisan migrate:generate --template-path=resources/stub/anonymous-class-migr
 
 ### Migration like Laravel 9+ (anonymous class)
 
-By default, Generator will generate all migrations using the template before Laravel 9.
+In Laravel 9 migrations using **anonymous classes** were introduced.
+
+By default the Generator still creates the files using the syntax of versions prior to Laravel 9+.
 
 If you want to generate a Laravel 9+ migration version, just set the param `--anonymous` or `-A`.
 
@@ -131,9 +133,14 @@ php artisan migrate:generate --anonymous
 php artisan migrate:generate -A
 ```
 
+```diff
+-class CreateUserTable extends Migration
++return new class extends Migration
+```
+
 > ! **Note**
 > `--template-path` take precedence hover `--anonymous`.
-> To use `--anonymous`, you can't  use `--tp|template-path`
+> That is, if you want to use `--anonymous`, you can't  use `--tp|template-path`.
 
 
 ### Options

--- a/config/config.php
+++ b/config/config.php
@@ -13,4 +13,15 @@ return [
         'view'        => '[datetime_prefix]_create_[table]_view.php',
         'foreign_key' => '[datetime_prefix]_add_foreign_keys_to_[table]_table.php',
     ],
+
+    /**
+     * Laravel 9x+ migration
+     */
+    'anonymous_class_migration' => [
+        'enabled' => env('LMG_ANONYMOUS_CLASS_MIGRATION_ENABLED', false),
+        'template_path' => env(
+            'LMG_ANONYMOUS_CLASS_MIGRATION_TEMPLATE_PATH',
+            __DIR__ . '/../resources/stub/anonymous-class-migration.stub'
+        ),
+    ],
 ];

--- a/resources/stub/anonymous-class-migration.stub
+++ b/resources/stub/anonymous-class-migration.stub
@@ -1,0 +1,26 @@
+<?php
+
+{{ use }}
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        {{ up }}
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        {{ down }}
+    }
+};

--- a/src/MigrationsGeneratorServiceProvider.php
+++ b/src/MigrationsGeneratorServiceProvider.php
@@ -75,6 +75,13 @@ class MigrationsGeneratorServiceProvider extends ServiceProvider
         $this->app->bind(MigrationInterface::class, Migration::class);
 
         $this->registerColumnTypeGenerator();
+
+        $stubPath = "{$this->app->resourcePath()}/stub";
+
+        $this->publishes([
+            __DIR__ . '/../resources/stub/migration.stub' => "{$stubPath}/migration.stub",
+            __DIR__ . '/../resources/stub/anonymous-class-migration.stub' => "{$stubPath}/anonymous-class-migration.stub",
+        ], 'templates');
     }
 
     public function boot()

--- a/src/Setting.php
+++ b/src/Setting.php
@@ -44,6 +44,9 @@ class Setting
     /** @var string */
     private $fkFilename;
 
+    /** @var boolean */
+    private $anonymous;
+
     /**
      * @return string
      */
@@ -218,5 +221,21 @@ class Setting
     public function setDate(Carbon $date): void
     {
         $this->date = $date;
+    }
+
+    /**
+     * @param  bool  $anonymous
+     */
+    public function setAnonymous(bool $anonymous): void
+    {
+        $this->anonymous = $anonymous;
+    }
+
+    /**
+     * @return bool
+     */
+    public function asAnonymousClass(): bool
+    {
+        return $this->anonymous;
     }
 }


### PR DESCRIPTION
migrations like Laravel 9x by @tiagofrancafernandes
allow generate migrations using anonymous classes like Laravel 9.

- Created stub
- Added param to use this feature
- Updated README.md
