### PR TITLE
Generate migrations with custom column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,19 @@ Laravel will automatically register service provider for you.
 
 Auto-discovery is not available in Lumen, you need some modification on `bootstrap/app.php`.
 
-#### Enable facade
+#### Enable Facade
 
 Uncomment the following line.
 
-```
+```php
 $app->withFacades();
 ```
 
-#### Register provider
+#### Register Provider
 
 Add following line into the `Register Service Providers` section.
 
-```
+```php
 $app->register(\KitLoong\MigrationsGenerator\MigrationsGeneratorServiceProvider::class);
 ```
 
@@ -98,7 +98,7 @@ You can also specify the connection name if you are not using your default conne
 php artisan migrate:generate --connection="connection_name"
 ```
 
-### Squash migrations
+### Squash Migrations
 
 By default, Generator will generate multiple migration files for each table. 
 
@@ -112,28 +112,45 @@ php artisan migrate:generate --squash
 
 Run `php artisan help migrate:generate` for a list of options.
 
-|Options|Description|
-|---|---|
-|-c, --connection[=CONNECTION]|The database connection to use|
-|-t, --tables[=TABLES]|A list of Tables or Views you wish to Generate Migrations for separated by a comma: users,posts,comments|
-|-i, --ignore[=IGNORE]|A list of Tables or Views you wish to ignore, separated by a comma: users,posts,comments|
-|-p, --path[=PATH]|Where should the file be created?|
-|-tp, --template-path[=TEMPLATE-PATH]|The location of the template for this generator|
-|--date[=DATE]|Migrations will be created with specified date. Views and Foreign keys will be created with + 1 second. Date should be in format suitable for `Carbon::parse`|
-|--table-filename[=TABLE-FILENAME]|Define table migration filename, default pattern: `[datetime_prefix]\_create_[table]_table.php`|
-|--view-filename[=VIEW-FILENAME]|Define view migration filename, default pattern: `[datetime_prefix]\_create_[table]_view.php`|
-|--fk-filename[=FK-FILENAME]|Define foreign key migration filename, default pattern: `[datetime_prefix]\_add_foreign_keys_to_[table]_table.php`|
-|--default-index-names|Don\'t use db index names for migrations|
-|--default-fk-names|Don\'t use db foreign key names for migrations|
-|--use-db-collation|Follow db collations for migrations|
-|--skip-views|Don\'t generate views|
-|--squash|Generate all migrations into a single file|
+| Options                              | Description                                                                                                                                                   |
+|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -c, --connection[=CONNECTION]        | The database connection to use                                                                                                                                |
+| -t, --tables[=TABLES]                | A list of Tables or Views you wish to Generate Migrations for separated by a comma: users,posts,comments                                                      |
+| -i, --ignore[=IGNORE]                | A list of Tables or Views you wish to ignore, separated by a comma: users,posts,comments                                                                      |
+| -p, --path[=PATH]                    | Where should the file be created?                                                                                                                             |
+| -tp, --template-path[=TEMPLATE-PATH] | The location of the template for this generator                                                                                                               |
+| --date[=DATE]                        | Migrations will be created with specified date. Views and Foreign keys will be created with + 1 second. Date should be in format supported by `Carbon::parse` |
+| --table-filename[=TABLE-FILENAME]    | Define table migration filename, default pattern: `[datetime_prefix]\_create_[table]_table.php`                                                               |
+| --view-filename[=VIEW-FILENAME]      | Define view migration filename, default pattern: `[datetime_prefix]\_create_[table]_view.php`                                                                 |
+| --fk-filename[=FK-FILENAME]          | Define foreign key migration filename, default pattern: `[datetime_prefix]\_add_foreign_keys_to_[table]_table.php`                                            |
+| --default-index-names                | Don\'t use DB index names for migrations                                                                                                                      |
+| --default-fk-names                   | Don\'t use DB foreign key names for migrations                                                                                                                |
+| --use-db-collation                   | Generate migrations with existing DB collation                                                                                                                |
+| --skip-views                         | Don\'t generate views                                                                                                                                         |
+| --squash                             | Generate all migrations into a single file                                                                                                                    |
 
-## SQLite alter foreign key
+## SQLite Alter Foreign Key
 
 The generator first generates all tables and then adds foreign keys to existing tables.
+
 However, SQLite only supports foreign keys upon creation of the table and not when tables are altered.
 *_add_foreign_keys_* migrations will still be generated, however will get omitted if migrate to SQLite type database.
+
+## PostgreSQL Custom Column Type
+
+The generator will register custom data type from `pg_type`, then generate migration as
+
+```php
+public function up()
+{
+    Schema::create('table', function (Blueprint $table) {
+        ...
+    });
+    DB::statement("ALTER TABLE table ADD column custom_type NOT NULL");
+}
+```
+
+Note that the new `column` is always added at the end of the created `table` which means the ordering of the column generated in migration will differ from what we have from the schema.
 
 ## Thank You
 

--- a/src/DBAL/Models/DBALCustomColumn.php
+++ b/src/DBAL/Models/DBALCustomColumn.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace KitLoong\MigrationsGenerator\DBAL\Models;
+
+use Doctrine\DBAL\Schema\Column as DoctrineDBALColumn;
+use Doctrine\DBAL\Schema\TableDiff;
+use Illuminate\Support\Facades\DB;
+use KitLoong\MigrationsGenerator\Schema\Models\CustomColumn;
+
+abstract class DBALCustomColumn implements CustomColumn
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $tableName;
+
+    /**
+     * @var string[]
+     */
+    private $sqls;
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function __construct(string $table, DoctrineDBALColumn $column)
+    {
+        $this->name      = $column->getName();
+        $this->tableName = $table;
+        $this->sqls      = DB::getDoctrineSchemaManager()->getDatabasePlatform()->getAlterTableSQL(new TableDiff($this->tableName, [$column]));
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getTableName(): string
+    {
+        return $this->tableName;
+    }
+
+    public function getSqls(): array
+    {
+        return $this->sqls;
+    }
+}

--- a/src/DBAL/Models/DBALCustomColumn.php
+++ b/src/DBAL/Models/DBALCustomColumn.php
@@ -34,16 +34,25 @@ abstract class DBALCustomColumn implements CustomColumn
         $this->sqls      = DB::getDoctrineSchemaManager()->getDatabasePlatform()->getAlterTableSQL(new TableDiff($this->tableName, [$column]));
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getName(): string
     {
         return $this->name;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getTableName(): string
     {
         return $this->tableName;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getSqls(): array
     {
         return $this->sqls;

--- a/src/DBAL/Models/DBALTable.php
+++ b/src/DBAL/Models/DBALTable.php
@@ -6,7 +6,9 @@ use Doctrine\DBAL\Schema\Column as DoctrineDBALColumn;
 use Doctrine\DBAL\Schema\Index as DoctrineDBALIndex;
 use Doctrine\DBAL\Schema\Table as DoctrineDBALTable;
 use Illuminate\Support\Collection;
+use KitLoong\MigrationsGenerator\DBAL\Types\CustomType;
 use KitLoong\MigrationsGenerator\Schema\Models\Column;
+use KitLoong\MigrationsGenerator\Schema\Models\CustomColumn;
 use KitLoong\MigrationsGenerator\Schema\Models\Index;
 use KitLoong\MigrationsGenerator\Schema\Models\Table;
 
@@ -21,6 +23,11 @@ abstract class DBALTable implements Table
      * @var \Illuminate\Support\Collection<\KitLoong\MigrationsGenerator\Schema\Models\Column>
      */
     protected $columns;
+
+    /**
+     * @var \Illuminate\Support\Collection<\KitLoong\MigrationsGenerator\Schema\Models\CustomColumn>
+     */
+    protected $customColumns;
 
     /**
      * @var string
@@ -43,10 +50,22 @@ abstract class DBALTable implements Table
     {
         $this->name      = $table->getName();
         $this->collation = $table->getOptions()['collation'] ?? null;
-        $this->columns   = (new Collection($columns))->map(function (DoctrineDBALColumn $column) use ($table) {
-            return $this->makeColumn($table->getName(), $column);
-        })->values();
-        $this->indexes   = (new Collection($indexes))->map(function (DoctrineDBALIndex $index) use ($table) {
+
+        $this->columns = (new Collection($columns))->reduce(function (Collection $columns, DoctrineDBALColumn $column) use ($table) {
+            if (!$column->getType() instanceof CustomType) {
+                $columns->push($this->makeColumn($table->getName(), $column));
+            }
+            return $columns;
+        }, new Collection())->values();
+
+        $this->customColumns = (new Collection($columns))->reduce(function (Collection $columns, DoctrineDBALColumn $column) use ($table) {
+            if ($column->getType() instanceof CustomType) {
+                $columns->push($this->makeCustomColumn($table->getName(), $column));
+            }
+            return $columns;
+        }, new Collection())->values();
+
+        $this->indexes = (new Collection($indexes))->map(function (DoctrineDBALIndex $index) use ($table) {
             return $this->makeIndex($table->getName(), $index);
         })->values();
 
@@ -68,6 +87,15 @@ abstract class DBALTable implements Table
      * @return \KitLoong\MigrationsGenerator\Schema\Models\Column
      */
     abstract protected function makeColumn(string $table, DoctrineDBALColumn $column): Column;
+
+    /**
+     * Make a CustomColumn instance.
+     *
+     * @param  string  $table
+     * @param  \Doctrine\DBAL\Schema\Column  $column
+     * @return \KitLoong\MigrationsGenerator\Schema\Models\CustomColumn
+     */
+    abstract protected function makeCustomColumn(string $table, DoctrineDBALColumn $column): CustomColumn;
 
     /**
      * Make an Index instance.
@@ -92,6 +120,14 @@ abstract class DBALTable implements Table
     public function getColumns(): Collection
     {
         return $this->columns;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCustomColumns(): Collection
+    {
+        return $this->customColumns;
     }
 
     /**

--- a/src/DBAL/Models/MySQL/MySQLCustomColumn.php
+++ b/src/DBAL/Models/MySQL/MySQLCustomColumn.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace KitLoong\MigrationsGenerator\DBAL\Models\MySQL;
+
+use KitLoong\MigrationsGenerator\DBAL\Models\DBALCustomColumn;
+
+class MySQLCustomColumn extends DBALCustomColumn
+{
+}

--- a/src/DBAL/Models/MySQL/MySQLTable.php
+++ b/src/DBAL/Models/MySQL/MySQLTable.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema\Column as DoctrineDBALColumn;
 use Doctrine\DBAL\Schema\Index as DoctrineDBALIndex;
 use KitLoong\MigrationsGenerator\DBAL\Models\DBALTable;
 use KitLoong\MigrationsGenerator\Schema\Models\Column;
+use KitLoong\MigrationsGenerator\Schema\Models\CustomColumn;
 use KitLoong\MigrationsGenerator\Schema\Models\Index;
 
 class MySQLTable extends DBALTable
@@ -23,6 +24,15 @@ class MySQLTable extends DBALTable
     protected function makeColumn(string $table, DoctrineDBALColumn $column): Column
     {
         return new MySQLColumn($table, $column);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Doctrine\DBAL\Exception
+     */
+    protected function makeCustomColumn(string $table, DoctrineDBALColumn $column): CustomColumn
+    {
+        return new MySQLCustomColumn($table, $column);
     }
 
     /**

--- a/src/DBAL/Models/PgSQL/PgSQLCustomColumn.php
+++ b/src/DBAL/Models/PgSQL/PgSQLCustomColumn.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace KitLoong\MigrationsGenerator\DBAL\Models\PgSQL;
+
+use KitLoong\MigrationsGenerator\DBAL\Models\DBALCustomColumn;
+
+class PgSQLCustomColumn extends DBALCustomColumn
+{
+}

--- a/src/DBAL/Models/PgSQL/PgSQLTable.php
+++ b/src/DBAL/Models/PgSQL/PgSQLTable.php
@@ -8,6 +8,7 @@ use KitLoong\MigrationsGenerator\DBAL\Models\DBALTable;
 use KitLoong\MigrationsGenerator\Repositories\Entities\PgSQL\IndexDefinition;
 use KitLoong\MigrationsGenerator\Repositories\PgSQLRepository;
 use KitLoong\MigrationsGenerator\Schema\Models\Column;
+use KitLoong\MigrationsGenerator\Schema\Models\CustomColumn;
 use KitLoong\MigrationsGenerator\Schema\Models\Index;
 
 class PgSQLTable extends DBALTable
@@ -31,6 +32,15 @@ class PgSQLTable extends DBALTable
     protected function makeColumn(string $table, DoctrineDBALColumn $column): Column
     {
         return new PgSQLColumn($table, $column);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Doctrine\DBAL\Exception
+     */
+    protected function makeCustomColumn(string $table, DoctrineDBALColumn $column): CustomColumn
+    {
+        return new PgSQLCustomColumn($table, $column);
     }
 
     /**

--- a/src/DBAL/Models/SQLSrv/SQLSrvCustomColumn.php
+++ b/src/DBAL/Models/SQLSrv/SQLSrvCustomColumn.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace KitLoong\MigrationsGenerator\DBAL\Models\SQLSrv;
+
+use KitLoong\MigrationsGenerator\DBAL\Models\DBALCustomColumn;
+
+class SQLSrvCustomColumn extends DBALCustomColumn
+{
+}

--- a/src/DBAL/Models/SQLSrv/SQLSrvTable.php
+++ b/src/DBAL/Models/SQLSrv/SQLSrvTable.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema\Column as DoctrineDBALColumn;
 use Doctrine\DBAL\Schema\Index as DoctrineDBALIndex;
 use KitLoong\MigrationsGenerator\DBAL\Models\DBALTable;
 use KitLoong\MigrationsGenerator\Schema\Models\Column;
+use KitLoong\MigrationsGenerator\Schema\Models\CustomColumn;
 use KitLoong\MigrationsGenerator\Schema\Models\Index;
 
 class SQLSrvTable extends DBALTable
@@ -23,6 +24,15 @@ class SQLSrvTable extends DBALTable
     protected function makeColumn(string $table, DoctrineDBALColumn $column): Column
     {
         return new SQLSrvColumn($table, $column);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Doctrine\DBAL\Exception
+     */
+    protected function makeCustomColumn(string $table, DoctrineDBALColumn $column): CustomColumn
+    {
+        return new SQLSrvCustomColumn($table, $column);
     }
 
     /**

--- a/src/DBAL/Models/SQLite/SQLiteCustomColumn.php
+++ b/src/DBAL/Models/SQLite/SQLiteCustomColumn.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace KitLoong\MigrationsGenerator\DBAL\Models\SQLite;
+
+use KitLoong\MigrationsGenerator\DBAL\Models\DBALCustomColumn;
+
+class SQLiteCustomColumn extends DBALCustomColumn
+{
+}

--- a/src/DBAL/Models/SQLite/SQLiteTable.php
+++ b/src/DBAL/Models/SQLite/SQLiteTable.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema\Column as DoctrineDBALColumn;
 use Doctrine\DBAL\Schema\Index as DoctrineDBALIndex;
 use KitLoong\MigrationsGenerator\DBAL\Models\DBALTable;
 use KitLoong\MigrationsGenerator\Schema\Models\Column;
+use KitLoong\MigrationsGenerator\Schema\Models\CustomColumn;
 use KitLoong\MigrationsGenerator\Schema\Models\Index;
 
 class SQLiteTable extends DBALTable
@@ -23,6 +24,15 @@ class SQLiteTable extends DBALTable
     protected function makeColumn(string $table, DoctrineDBALColumn $column): Column
     {
         return new SQLiteColumn($table, $column);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Doctrine\DBAL\Exception
+     */
+    protected function makeCustomColumn(string $table, DoctrineDBALColumn $column): CustomColumn
+    {
+        return new SQLiteCustomColumn($table, $column);
     }
 
     /**

--- a/src/DBAL/RegisterColumnType.php
+++ b/src/DBAL/RegisterColumnType.php
@@ -49,7 +49,7 @@ class RegisterColumnType
     public function handle(): void
     {
         $this->registerLaravelColumnType();
-        $this->registerLaravelCustomType();
+        $this->registerLaravelCustomColumnType();
 
         $doctrineTypes = [
             Driver::MYSQL()->getValue()  => [
@@ -136,7 +136,7 @@ class RegisterColumnType
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) to suppress `getSQLDeclaration` warning.
      */
-    private function registerLaravelCustomType(): void
+    private function registerLaravelCustomColumnType(): void
     {
         foreach ($this->getCustomTypes() as $type) {
             $customType       = new class () extends CustomType {

--- a/src/DBAL/Types/CustomType.php
+++ b/src/DBAL/Types/CustomType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace KitLoong\MigrationsGenerator\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+
+abstract class CustomType extends Type
+{
+}

--- a/src/MigrateGenerateCommand.php
+++ b/src/MigrateGenerateCommand.php
@@ -32,13 +32,13 @@ class MigrateGenerateCommand extends Command
                             {--i|ignore= : A list of Tables or Views you wish to ignore, separated by a comma: users,posts,comments}
                             {--p|path= : Where should the file be created?}
                             {--tp|template-path= : The location of the template for this generator}
-                            {--date= : Migrations will be created with specified date. Views and Foreign keys will be created with + 1 second. Date should be in format suitable for Carbon::parse}
+                            {--date= : Migrations will be created with specified date. Views and Foreign keys will be created with + 1 second. Date should be in format supported by Carbon::parse}
                             {--table-filename= : Define table migration filename, default pattern: [datetime_prefix]_create_[table]_table.php}
                             {--view-filename= : Define view migration filename, default pattern: [datetime_prefix]_create_[table]_view.php}
                             {--fk-filename= : Define foreign key migration filename, default pattern: [datetime_prefix]_add_foreign_keys_to_[table]_table.php}
-                            {--default-index-names : Don\'t use db index names for migrations}
-                            {--default-fk-names : Don\'t use db foreign key names for migrations}
-                            {--use-db-collation : Follow db collations for migrations}
+                            {--default-index-names : Don\'t use DB index names for migrations}
+                            {--default-fk-names : Don\'t use DB foreign key names for migrations}
+                            {--use-db-collation : Generate migrations with existing DB collation}
                             {--skip-views : Don\'t generate views}
                             {--squash : Generate all migrations into a single file}';
 

--- a/src/Migration/Blueprint/CustomBlueprint.php
+++ b/src/Migration/Blueprint/CustomBlueprint.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace KitLoong\MigrationsGenerator\Migration\Blueprint;
+
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Support\MethodStringHelper;
+
+class CustomBlueprint implements WritableBlueprint
+{
+    use Stringable;
+    use MethodStringHelper;
+
+    /**
+     * @var string
+     */
+    private $sql;
+
+    /**
+     * CustomBlueprint constructor.
+     *
+     * @param  string  $sql  The SQL statement.
+     */
+    public function __construct(string $sql)
+    {
+        $this->sql = $sql;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toString(): string
+    {
+        $method = $this->connection('DB', 'statement');
+        $query  = $this->escapeDoubleQuote($this->sql);
+        return "$method(\"$query\");";
+    }
+}

--- a/src/Migration/Blueprint/CustomBlueprint.php
+++ b/src/Migration/Blueprint/CustomBlueprint.php
@@ -3,6 +3,7 @@
 namespace KitLoong\MigrationsGenerator\Migration\Blueprint;
 
 use KitLoong\MigrationsGenerator\Migration\Blueprint\Support\MethodStringHelper;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Support\Stringable;
 
 class CustomBlueprint implements WritableBlueprint
 {

--- a/src/Migration/Blueprint/SchemaBlueprint.php
+++ b/src/Migration/Blueprint/SchemaBlueprint.php
@@ -3,17 +3,25 @@
 namespace KitLoong\MigrationsGenerator\Migration\Blueprint;
 
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\SchemaBuilder;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Support\MethodStringHelper;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Support\Stringable;
 use KitLoong\MigrationsGenerator\Migration\Enum\Space;
-use KitLoong\MigrationsGenerator\Setting;
 use KitLoong\MigrationsGenerator\Support\TableName;
 
 class SchemaBlueprint implements WritableBlueprint
 {
     use Stringable;
+    use MethodStringHelper;
     use TableName;
 
+    /**
+     * @var string
+     */
     private $table;
-    private $connection;
+
+    /**
+     * @var \KitLoong\MigrationsGenerator\Enum\Migrations\Method\SchemaBuilder
+     */
     private $schemaBuilder;
 
     /** @var \KitLoong\MigrationsGenerator\Migration\Blueprint\TableBlueprint|null */
@@ -22,13 +30,11 @@ class SchemaBlueprint implements WritableBlueprint
     /**
      * SchemaBlueprint constructor.
      *
-     * @param  string  $connection  Connection name.
      * @param  string  $table  Table name.
      * @param  \KitLoong\MigrationsGenerator\Enum\Migrations\Method\SchemaBuilder  $schemaBuilder  SchemaBuilder name.
      */
-    public function __construct(string $connection, string $table, SchemaBuilder $schemaBuilder)
+    public function __construct(string $table, SchemaBuilder $schemaBuilder)
     {
-        $this->connection    = $connection;
         $this->table         = $table;
         $this->schemaBuilder = $schemaBuilder;
         $this->blueprint     = null;
@@ -56,12 +62,7 @@ class SchemaBlueprint implements WritableBlueprint
      */
     private function getLines(): array
     {
-        $setting = app(Setting::class);
-
-        $schema = "Schema::$this->schemaBuilder";
-        if ($this->connection !== $setting->getDefaultConnection()) {
-            $schema = "Schema::" . SchemaBuilder::CONNECTION() . "('$this->connection')->$this->schemaBuilder";
-        }
+        $schema = $this->connection('Schema', $this->schemaBuilder);
 
         $tableWithoutPrefix = $this->stripPrefix($this->table);
 

--- a/src/Migration/Blueprint/Support/MergeTimestamps.php
+++ b/src/Migration/Blueprint/Support/MergeTimestamps.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace KitLoong\MigrationsGenerator\Migration\Blueprint;
+namespace KitLoong\MigrationsGenerator\Migration\Blueprint\Support;
 
 use Illuminate\Support\Facades\DB;
 use KitLoong\MigrationsGenerator\Enum\Driver;
 use KitLoong\MigrationsGenerator\Enum\Migrations\ColumnName;
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\ColumnModifier;
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\ColumnType;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Method;
 
 trait MergeTimestamps
 {

--- a/src/Migration/Blueprint/Support/MethodStringHelper.php
+++ b/src/Migration/Blueprint/Support/MethodStringHelper.php
@@ -21,6 +21,6 @@ trait MethodStringHelper
             return "$class::$method";
         }
 
-        return "$class::" . SchemaBuilder::CONNECTION() . "->$method";
+        return "$class::" . SchemaBuilder::CONNECTION() . "('" . DB::getName() . "')->$method";
     }
 }

--- a/src/Migration/Blueprint/Support/MethodStringHelper.php
+++ b/src/Migration/Blueprint/Support/MethodStringHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace KitLoong\MigrationsGenerator\Migration\Blueprint\Support;
+
+use Illuminate\Support\Facades\DB;
+use KitLoong\MigrationsGenerator\Enum\Migrations\Method\SchemaBuilder;
+use KitLoong\MigrationsGenerator\Setting;
+
+trait MethodStringHelper
+{
+    /**
+     * Generates method string with `connection` if `--connection=other` option is used.
+     *
+     * @param  string  $class
+     * @param  string  $method
+     * @return string
+     */
+    public function connection(string $class, string $method): string
+    {
+        if (DB::getName() === app(Setting::class)->getDefaultConnection()) {
+            return "$class::$method";
+        }
+
+        return "$class::" . SchemaBuilder::CONNECTION() . "->$method";
+    }
+}

--- a/src/Migration/Blueprint/Support/Stringable.php
+++ b/src/Migration/Blueprint/Support/Stringable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace KitLoong\MigrationsGenerator\Migration\Blueprint;
+namespace KitLoong\MigrationsGenerator\Migration\Blueprint\Support;
 
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection;

--- a/src/Migration/Blueprint/TableBlueprint.php
+++ b/src/Migration/Blueprint/TableBlueprint.php
@@ -3,6 +3,8 @@
 namespace KitLoong\MigrationsGenerator\Migration\Blueprint;
 
 use Illuminate\Support\Collection;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Support\MergeTimestamps;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Support\Stringable;
 use KitLoong\MigrationsGenerator\Migration\Enum\Space;
 
 class TableBlueprint implements WritableBlueprint

--- a/src/Migration/Blueprint/ViewBlueprint.php
+++ b/src/Migration/Blueprint/ViewBlueprint.php
@@ -2,25 +2,31 @@
 
 namespace KitLoong\MigrationsGenerator\Migration\Blueprint;
 
-use Illuminate\Support\Facades\Config;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Support\MethodStringHelper;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Support\Stringable;
 
 class ViewBlueprint implements WritableBlueprint
 {
     use Stringable;
+    use MethodStringHelper;
 
-    private $connection;
+    /**
+     * @var string
+     */
     private $view;
+
+    /**
+     * @var string
+     */
     private $createViewSql;
 
     /**
      * ViewBlueprint constructor.
      *
-     * @param  string  $connection  Connection name.
      * @param  string  $view  View name.
      */
-    public function __construct(string $connection, string $view)
+    public function __construct(string $view)
     {
-        $this->connection    = $connection;
         $this->view          = $view;
         $this->createViewSql = '';
     }
@@ -38,10 +44,7 @@ class ViewBlueprint implements WritableBlueprint
      */
     public function toString(): string
     {
-        $dbStatement = 'DB::statement';
-        if ($this->connection !== Config::get('database.default')) {
-            $dbStatement = "DB::connection('" . $this->connection . "')->statement";
-        }
+        $dbStatement = $this->connection('DB', 'statement');
 
         $query = $this->escapeDoubleQuote("DROP VIEW IF EXISTS $this->view");
         if ($this->createViewSql !== '') {

--- a/src/Migration/ForeignKeyMigration.php
+++ b/src/Migration/ForeignKeyMigration.php
@@ -3,7 +3,6 @@
 namespace KitLoong\MigrationsGenerator\Migration;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\SchemaBuilder;
 use KitLoong\MigrationsGenerator\Migration\Blueprint\SchemaBlueprint;
 use KitLoong\MigrationsGenerator\Migration\Blueprint\TableBlueprint;
@@ -66,7 +65,6 @@ class ForeignKeyMigration
     private function getSchemaBlueprint(string $table): SchemaBlueprint
     {
         return new SchemaBlueprint(
-            DB::getName(),
             $table,
             SchemaBuilder::TABLE()
         );

--- a/src/Migration/TableMigration.php
+++ b/src/Migration/TableMigration.php
@@ -139,7 +139,6 @@ class TableMigration
     private function getSchemaBlueprint(Table $table, SchemaBuilder $schemaBuilder): SchemaBlueprint
     {
         return new SchemaBlueprint(
-            DB::getName(),
             $table->getName(),
             $schemaBuilder
         );

--- a/src/Migration/TableMigration.php
+++ b/src/Migration/TableMigration.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use KitLoong\MigrationsGenerator\Enum\Driver;
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\SchemaBuilder;
 use KitLoong\MigrationsGenerator\Enum\Migrations\Property\TableProperty;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\CustomBlueprint;
 use KitLoong\MigrationsGenerator\Migration\Blueprint\SchemaBlueprint;
 use KitLoong\MigrationsGenerator\Migration\Blueprint\TableBlueprint;
 use KitLoong\MigrationsGenerator\Migration\Generator\ColumnGenerator;
@@ -68,6 +69,23 @@ class TableMigration
         $up->setBlueprint($blueprint);
 
         return $up;
+    }
+
+    /**
+     * Generate custom statements.
+     *
+     * @param  \KitLoong\MigrationsGenerator\Schema\Models\Table  $table
+     * @return \KitLoong\MigrationsGenerator\Migration\Blueprint\CustomBlueprint[]
+     */
+    public function upAdditionalStatements(Table $table): array
+    {
+        $statements = [];
+        foreach ($table->getCustomColumns() as $column) {
+            foreach ($column->getSqls() as $sql) {
+                $statements[] = new CustomBlueprint($sql);
+            }
+        }
+        return $statements;
     }
 
     /**

--- a/src/Migration/ViewMigration.php
+++ b/src/Migration/ViewMigration.php
@@ -2,7 +2,6 @@
 
 namespace KitLoong\MigrationsGenerator\Migration;
 
-use Illuminate\Support\Facades\DB;
 use KitLoong\MigrationsGenerator\Migration\Blueprint\ViewBlueprint;
 use KitLoong\MigrationsGenerator\Schema\Models\View;
 
@@ -16,7 +15,7 @@ class ViewMigration
      */
     public function up(View $view): ViewBlueprint
     {
-        $viewBlueprint = new ViewBlueprint(DB::getName(), $view->getQuotedName());
+        $viewBlueprint = new ViewBlueprint($view->getQuotedName());
         $viewBlueprint->setCreateViewSql($view->getCreateViewSql());
         return $viewBlueprint;
     }
@@ -29,6 +28,6 @@ class ViewMigration
      */
     public function down(View $view): ViewBlueprint
     {
-        return new ViewBlueprint(DB::getName(), $view->getQuotedName());
+        return new ViewBlueprint($view->getQuotedName());
     }
 }

--- a/src/Migration/Writer/SquashWriter.php
+++ b/src/Migration/Writer/SquashWriter.php
@@ -2,6 +2,7 @@
 
 namespace KitLoong\MigrationsGenerator\Migration\Writer;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use KitLoong\MigrationsGenerator\Migration\Blueprint\WritableBlueprint;
 use KitLoong\MigrationsGenerator\Migration\Enum\Space;
@@ -23,18 +24,24 @@ class SquashWriter
      * Append new content into `up`.
      * Prepend new content into `down`.
      *
-     * @param  \KitLoong\MigrationsGenerator\Migration\Blueprint\WritableBlueprint  $upBlueprint
-     * @param  \KitLoong\MigrationsGenerator\Migration\Blueprint\WritableBlueprint  $downBlueprint
+     * @param  \Illuminate\Support\Collection<\KitLoong\MigrationsGenerator\Migration\Blueprint\WritableBlueprint>  $upBlueprints
+     * @param  \Illuminate\Support\Collection<\KitLoong\MigrationsGenerator\Migration\Blueprint\WritableBlueprint>  $downBlueprints
      */
-    public function writeToTemp(WritableBlueprint $upBlueprint, WritableBlueprint $downBlueprint): void
+    public function writeToTemp(Collection $upBlueprints, Collection $downBlueprints): void
     {
         $upTempPath  = $this->filenameHelper->makeUpTempPath();
         $prettySpace = $this->getSpaceIfFileExists($upTempPath);
-        File::append($upTempPath, $prettySpace . $upBlueprint->toString());
+        $upString    = $upBlueprints->map(function (WritableBlueprint $up) {
+            return $up->toString();
+        })->implode(Space::LINE_BREAK() . Space::TAB() . Space::TAB()); // Add tab to prettify
+        File::append($upTempPath, $prettySpace . $upString);
 
         $downTempPath = $this->filenameHelper->makeDownTempPath();
         $prettySpace  = $this->getSpaceIfFileExists($downTempPath);
-        File::prepend($downTempPath, $downBlueprint->toString() . $prettySpace);
+        $downString   = $downBlueprints->map(function (WritableBlueprint $down) {
+            return $down->toString();
+        })->implode(Space::LINE_BREAK() . Space::TAB() . Space::TAB()); // Add tab to prettify
+        File::prepend($downTempPath, $downString . $prettySpace);
     }
 
     /**

--- a/src/Repositories/PgSQLRepository.php
+++ b/src/Repositories/PgSQLRepository.php
@@ -156,4 +156,31 @@ class PgSQLRepository extends Repository
         }
         return $definitions;
     }
+
+    /**
+     * Get a list of custom data types.
+     *
+     * @source https://stackoverflow.com/questions/3660787/how-to-list-custom-types-using-postgres-information-schema
+     * @return \Illuminate\Support\Collection<string>
+     */
+    public function getCustomDataTypes(): Collection
+    {
+        $searchPath = DB::connection()->getConfig('search_path') ?: DB::connection()->getConfig('schema');
+
+        $rows  = DB::select(
+            "SELECT n.nspname as schema, t.typname as type
+                    FROM pg_type t
+                        LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+                    WHERE (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
+                        AND NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid)
+                        AND n.nspname IN ('$searchPath');"
+        );
+        $types = new Collection();
+        if (count($rows) > 0) {
+            foreach ($rows as $row) {
+                $types->push($row->type);
+            }
+        }
+        return $types;
+    }
 }

--- a/src/Schema/Models/Column.php
+++ b/src/Schema/Models/Column.php
@@ -4,6 +4,10 @@ namespace KitLoong\MigrationsGenerator\Schema\Models;
 
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\ColumnType;
 
+/**
+ * Table column. Column type supported by the framework.
+ * See https://laravel.com/docs/9.x/migrations#available-column-types
+ */
 interface Column extends Model
 {
     /**

--- a/src/Schema/Models/CustomColumn.php
+++ b/src/Schema/Models/CustomColumn.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace KitLoong\MigrationsGenerator\Schema\Models;
+
+/**
+ * Table column. Column type which is not supported by the framework.
+ */
+interface CustomColumn extends Model
+{
+    /**
+     * Get the column name.
+     *
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * Get the table name.
+     *
+     * @return string
+     */
+    public function getTableName(): string;
+
+    /**
+     * Get the ALTER table ADD column SQL.
+     *
+     * @return string[]
+     */
+    public function getSqls(): array;
+}

--- a/src/Schema/Models/Table.php
+++ b/src/Schema/Models/Table.php
@@ -21,6 +21,13 @@ interface Table extends Model
     public function getColumns(): Collection;
 
     /**
+     * Get a list of custom columns.
+     *
+     * @return \Illuminate\Support\Collection<\KitLoong\MigrationsGenerator\Schema\Models\CustomColumn>
+     */
+    public function getCustomColumns(): Collection;
+
+    /**
      * Get a list of indexes.
      *
      * @return \Illuminate\Support\Collection<\KitLoong\MigrationsGenerator\Schema\Models\Index>

--- a/tests/Feature/PgSQL/CommandTest.php
+++ b/tests/Feature/PgSQL/CommandTest.php
@@ -26,6 +26,10 @@ class CommandTest extends PgSQLTestCase
             );
 
             DB::statement(
+                "ALTER TABLE all_columns_pgsql ADD COLUMN status my_status NOT NULL"
+            );
+
+            DB::statement(
                 "ALTER TABLE all_columns_pgsql ADD COLUMN timestamp_default_timezone_now timestamp(0) without time zone DEFAULT timezone('Europe/Rome'::text, now()) NOT NULL"
             );
         };
@@ -47,6 +51,23 @@ class CommandTest extends PgSQLTestCase
         };
 
         $this->verify($migrateTemplates, $generateMigrations, $beforeVerify);
+    }
+
+    public function testSquashUp()
+    {
+        $migrateTemplates = function () {
+            $this->migrateGeneral('pgsql');
+
+            DB::statement(
+                "ALTER TABLE all_columns_pgsql ADD COLUMN status my_status NOT NULL"
+            );
+        };
+
+        $generateMigrations = function () {
+            $this->generateMigrations(['--squash' => true]);
+        };
+
+        $this->verify($migrateTemplates, $generateMigrations);
     }
 
     public function testCollation()

--- a/tests/Feature/PgSQL/PgSQLTestCase.php
+++ b/tests/Feature/PgSQL/PgSQLTestCase.php
@@ -29,6 +29,21 @@ abstract class PgSQLTestCase extends FeatureTestCase
         ]);
     }
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create for custom column type test.
+        DB::statement("CREATE TYPE my_status AS enum ('PENDING', 'ACTIVE', 'SUSPENDED')");
+    }
+
+    protected function tearDown(): void
+    {
+        DB::statement("DROP TYPE IF EXISTS my_status CASCADE");
+
+        parent::tearDown();
+    }
+
     protected function dumpSchemaAs(string $destination): void
     {
         $command = sprintf(

--- a/tests/Feature/PgSQL/TablePrefixTest.php
+++ b/tests/Feature/PgSQL/TablePrefixTest.php
@@ -1,20 +1,26 @@
 <?php
 
-namespace KitLoong\MigrationsGenerator\Tests\Feature\MySQL57;
+namespace KitLoong\MigrationsGenerator\Tests\Feature\PgSQL;
 
-class TablePrefixTest extends MySQL57TestCase
+use Illuminate\Support\Facades\DB;
+
+class TablePrefixTest extends PgSQLTestCase
 {
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('database.connections.mysql57.prefix', 'kit_');
+        $app['config']->set('database.connections.pgsql.prefix', 'kit_');
     }
 
     public function testTablePrefix()
     {
         $migrateTemplates = function () {
-            $this->migrateGeneral('mysql57');
+            $this->migrateGeneral('pgsql');
+
+            DB::statement(
+                "ALTER TABLE kit_all_columns_pgsql ADD COLUMN status my_status NOT NULL"
+            );
         };
 
         $generateMigrations = function () {
@@ -37,7 +43,7 @@ class TablePrefixTest extends MySQL57TestCase
 
         $this->dropAllTables();
 
-        $this->runMigrationsFrom('mysql57', $this->storageMigrations());
+        $this->runMigrationsFrom('pgsql', $this->storageMigrations());
 
         $this->truncateMigration();
         $this->dumpSchemaAs($this->storageSql('actual.sql'));

--- a/tests/MigrationWriterTest.php
+++ b/tests/MigrationWriterTest.php
@@ -2,6 +2,7 @@
 
 namespace KitLoong\MigrationsGenerator\Tests;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\SchemaBuilder;
 use KitLoong\MigrationsGenerator\Migration\Blueprint\SchemaBlueprint;
@@ -48,8 +49,8 @@ class MigrationWriterTest extends TestCase
             storage_path('migration.php'),
             config('generators.config.migration_template_path'),
             'Tester',
-            $up,
-            $down,
+            new Collection([$up]),
+            new Collection([$down]),
             MigrationFileType::TABLE()
         );
 

--- a/tests/MigrationWriterTest.php
+++ b/tests/MigrationWriterTest.php
@@ -28,7 +28,7 @@ class MigrationWriterTest extends TestCase
                 ->andReturn('test');
         });
 
-        $up        = new SchemaBlueprint('mysql', 'users', SchemaBuilder::CREATE());
+        $up        = new SchemaBlueprint('users', SchemaBuilder::CREATE());
         $blueprint = new TableBlueprint();
         $blueprint->setProperty('collation', 'utf-8');
         $blueprint->setProperty('something', 1);
@@ -42,7 +42,7 @@ class MigrationWriterTest extends TestCase
             ->chain('default', 'Test');
         $up->setBlueprint($blueprint);
 
-        $down = new SchemaBlueprint('mysql', 'users', SchemaBuilder::DROP_IF_EXISTS());
+        $down = new SchemaBlueprint('users', SchemaBuilder::DROP_IF_EXISTS());
 
         $migration = app(MigrationWriter::class);
         $migration->writeTo(

--- a/tests/resources/database/migrations/general/2020_03_21_000001_expected_create_quoted_name_db_view.php
+++ b/tests/resources/database/migrations/general/2020_03_21_000001_expected_create_quoted_name_db_view.php
@@ -18,8 +18,8 @@ class ExpectedCreateQuotedName_DB_View extends Migration
     public function up()
     {
         DB::statement(
-            "CREATE VIEW " . $this->quoteIdentifier('quoted-name-[db]-view')
-            . " AS SELECT * from " . $this->quoteIdentifier('quoted-name-[db]')
+            "CREATE VIEW " . $this->quoteIdentifier(DB::getTablePrefix() . 'quoted-name-[db]-view')
+            . " AS SELECT * from " . $this->quoteIdentifier(DB::getTablePrefix() . 'quoted-name-[db]')
         );
     }
 

--- a/tests/resources/database/migrations/general/2020_03_21_000001_expected_create_users_db_view.php
+++ b/tests/resources/database/migrations/general/2020_03_21_000001_expected_create_users_db_view.php
@@ -16,7 +16,7 @@ class ExpectedCreateUsers_DB_View extends Migration
      */
     public function up()
     {
-        DB::statement("CREATE VIEW users_[db]_view AS SELECT * from users_[db]");
+        DB::statement("CREATE VIEW users_[db]_view AS SELECT * from " . DB::getTablePrefix() . "users_[db]");
     }
 
     /**


### PR DESCRIPTION
Fixes #65 and #75

## How it works

This feature is dedicated to PostgreSQL v10 and above. 
See https://www.postgresql.org/docs/current/sql-createtype.html

The generator will register custom data type from `pg_type`, then generate migration as
```
public function up()
{
    Schema::create('table', function (Blueprint $table) {
        ...
    });
    DB::statement("ALTER TABLE table ADD column custom_type NOT NULL");
}
```

## !! Note

Note that the new `column` is always appended after the `table` is created which means the ordering of the column generated from migration will differ from what we have from the schema.
