### PR TITLE
Create models from the name of the tables

### DIFF
--- a/src/MigrateGenerateCommand.php
+++ b/src/MigrateGenerateCommand.php
@@ -51,6 +51,8 @@ class MigrateGenerateCommand extends Command
 
     protected $shouldLog = false;
 
+    protected $makeModel = false;
+
     protected $nextBatchNumber = 0;
 
     /**
@@ -239,6 +241,7 @@ class MigrateGenerateCommand extends Command
     {
         if (!$this->option('no-interaction')) {
             $this->shouldLog = $this->confirm('Do you want to log these migrations in the migrations table?', true);
+            $this->makeModel = $this->confirm('Do you want create model for the tables?', true);
         }
 
         if ($this->shouldLog) {
@@ -369,7 +372,7 @@ class MigrateGenerateCommand extends Command
     {
         $tables->each(function (string $table) {
             $path = $this->migration->writeTable(
-                $this->schema->getTable($table)
+                $this->schema->getTable($table), $this->makeModel
             );
 
             $this->info("Created: $path");

--- a/src/Migration/Migration.php
+++ b/src/Migration/Migration.php
@@ -184,7 +184,7 @@ class Migration implements MigrationInterface
                 $finalName = $finalName.ucfirst($name);
             }
         }else{
-            $finalName = $table;
+            $finalName = ucfirst($table);
         }
         File::put('app/Models/'.$finalName.'.php', '<?php
 

--- a/src/Migration/MigrationInterface.php
+++ b/src/Migration/MigrationInterface.php
@@ -15,7 +15,7 @@ interface MigrationInterface
      * @return string Generated file path.
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function writeTable(Table $table): string;
+    public function writeTable(Table $table, $makeModel): string;
 
     /**
      * Write table schema into temp files.


### PR DESCRIPTION
### How it works

After user runs **php artisan migrate:generate**

asks the user if he would like to create models from the table names. If true, a model file is generated in the app/Models folder.