### PR TITLE
Check the existence of `GENERATION_EXPRESSION` column

### DIFF
--- a/src/Repositories/MySQLRepository.php
+++ b/src/Repositories/MySQLRepository.php
@@ -2,8 +2,10 @@
 
 namespace KitLoong\MigrationsGenerator\Repositories;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use KitLoong\MigrationsGenerator\Repositories\Entities\MySQL\ShowColumn;
 use KitLoong\MigrationsGenerator\Repositories\Entities\ProcedureDefinition;
 
@@ -153,13 +155,31 @@ class MySQLRepository extends Repository
      */
     private function getGenerationExpression(string $table, string $column, string $extra): ?string
     {
-        $definition = DB::selectOne(
-            "SELECT GENERATION_EXPRESSION
+        try {
+            $definition = DB::selectOne(
+                "SELECT GENERATION_EXPRESSION
                 FROM information_schema.COLUMNS
                 WHERE TABLE_NAME = '$table'
                     AND COLUMN_NAME = '$column'
                     AND EXTRA = '$extra'"
-        );
+            );
+        } catch (QueryException $exception) {
+            // Check if error caused by missing column 'GENERATION_EXPRESSION'.
+            // The column is introduced since MySQL 5.7 and MariaDB 10.2.5.
+            // @see https://mariadb.com/kb/en/information-schema-columns-table/
+            // @see https://dev.mysql.com/doc/refman/5.7/en/information-schema-columns-table.html
+            if (
+                Str::contains(
+                    $exception->getMessage(),
+                    "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'GENERATION_EXPRESSION'",
+                    true
+                )
+            ) {
+                return null;
+            }
+
+            throw $exception;
+        }
 
         if ($definition === null) {
             return null;


### PR DESCRIPTION
## Description

Check if the error is caused by the missing column 'GENERATION_EXPRESSION'.

The column is introduced since MySQL 5.7 and MariaDB 10.2.5.

https://mariadb.com/kb/en/information-schema-columns-table/
https://dev.mysql.com/doc/refman/5.7/en/information-schema-columns-table.html