### PR TITLE
set modifiers of all final enum constants to be public

### DIFF
--- a/src/Enum/Driver.php
+++ b/src/Enum/Driver.php
@@ -15,8 +15,8 @@ use MyCLabs\Enum\Enum;
  */
 final class Driver extends Enum
 {
-    private const MYSQL  = 'mysql';
-    private const PGSQL  = 'pgsql';
-    private const SQLITE = 'sqlite';
-    private const SQLSRV = 'sqlsrv';
+    public const MYSQL  = 'mysql';
+    public const PGSQL  = 'pgsql';
+    public const SQLITE = 'sqlite';
+    public const SQLSRV = 'sqlsrv';
 }

--- a/src/Enum/Migrations/ColumnName.php
+++ b/src/Enum/Migrations/ColumnName.php
@@ -16,8 +16,8 @@ use MyCLabs\Enum\Enum;
  */
 final class ColumnName extends Enum
 {
-    private const CREATED_AT     = 'created_at';
-    private const DELETED_AT     = 'deleted_at';
-    private const REMEMBER_TOKEN = 'remember_token';
-    private const UPDATED_AT     = 'updated_at';
+    public const CREATED_AT     = 'created_at';
+    public const DELETED_AT     = 'deleted_at';
+    public const REMEMBER_TOKEN = 'remember_token';
+    public const UPDATED_AT     = 'updated_at';
 }

--- a/src/Enum/Migrations/Method/ColumnModifier.php
+++ b/src/Enum/Migrations/Method/ColumnModifier.php
@@ -25,17 +25,17 @@ use MyCLabs\Enum\Enum;
  */
 final class ColumnModifier extends Enum
 {
-    private const ALWAYS                = 'always';
-    private const AUTO_INCREMENT        = 'autoIncrement';
-    private const CHARSET               = 'charset';
-    private const COLLATION             = 'collation';
-    private const COMMENT               = 'comment';
-    private const DEFAULT               = 'default';
-    private const GENERATED_AS          = 'generatedAs';
-    private const NULLABLE              = 'nullable';
-    private const STORED_AS             = 'storedAs';
-    private const UNSIGNED              = 'unsigned';
-    private const USE_CURRENT           = 'useCurrent';
-    private const USE_CURRENT_ON_UPDATE = 'useCurrentOnUpdate';
-    private const VIRTUAL_AS            = 'virtualAs';
+    public const ALWAYS                = 'always';
+    public const AUTO_INCREMENT        = 'autoIncrement';
+    public const CHARSET               = 'charset';
+    public const COLLATION             = 'collation';
+    public const COMMENT               = 'comment';
+    public const DEFAULT               = 'default';
+    public const GENERATED_AS          = 'generatedAs';
+    public const NULLABLE              = 'nullable';
+    public const STORED_AS             = 'storedAs';
+    public const UNSIGNED              = 'unsigned';
+    public const USE_CURRENT           = 'useCurrent';
+    public const USE_CURRENT_ON_UPDATE = 'useCurrentOnUpdate';
+    public const VIRTUAL_AS            = 'virtualAs';
 }

--- a/src/Enum/Migrations/Method/Foreign.php
+++ b/src/Enum/Migrations/Method/Foreign.php
@@ -18,10 +18,10 @@ use MyCLabs\Enum\Enum;
  */
 class Foreign extends Enum
 {
-    private const DROP_FOREIGN = 'dropForeign';
-    private const FOREIGN      = 'foreign';
-    private const ON           = 'on';
-    private const ON_DELETE    = 'onDelete';
-    private const ON_UPDATE    = 'onUpdate';
-    private const REFERENCES   = 'references';
+    public const DROP_FOREIGN = 'dropForeign';
+    public const FOREIGN      = 'foreign';
+    public const ON           = 'on';
+    public const ON_DELETE    = 'onDelete';
+    public const ON_UPDATE    = 'onUpdate';
+    public const REFERENCES   = 'references';
 }

--- a/src/Enum/Migrations/Method/IndexType.php
+++ b/src/Enum/Migrations/Method/IndexType.php
@@ -18,10 +18,10 @@ use MyCLabs\Enum\Enum;
  */
 final class IndexType extends Enum
 {
-    private const FULLTEXT       = 'fullText';
-    private const FULLTEXT_CHAIN = 'fulltext'; // Use lowercase.
-    private const INDEX          = 'index';
-    private const PRIMARY        = 'primary';
-    private const SPATIAL_INDEX  = 'spatialIndex';
-    private const UNIQUE         = 'unique';
+    public const FULLTEXT       = 'fullText';
+    public const FULLTEXT_CHAIN = 'fulltext'; // Use lowercase.
+    public const INDEX          = 'index';
+    public const PRIMARY        = 'primary';
+    public const SPATIAL_INDEX  = 'spatialIndex';
+    public const UNIQUE         = 'unique';
 }

--- a/src/Enum/Migrations/Method/SchemaBuilder.php
+++ b/src/Enum/Migrations/Method/SchemaBuilder.php
@@ -17,9 +17,9 @@ use MyCLabs\Enum\Enum;
  */
 final class SchemaBuilder extends Enum
 {
-    private const CONNECTION     = 'connection';
-    private const CREATE         = 'create';
-    private const DROP_IF_EXISTS = 'dropIfExists';
-    private const HAS_TABLE      = 'hasTable';
-    private const TABLE          = 'table';
+    public const CONNECTION     = 'connection';
+    public const CREATE         = 'create';
+    public const DROP_IF_EXISTS = 'dropIfExists';
+    public const HAS_TABLE      = 'hasTable';
+    public const TABLE          = 'table';
 }

--- a/src/Enum/Migrations/Property/TableProperty.php
+++ b/src/Enum/Migrations/Property/TableProperty.php
@@ -15,7 +15,7 @@ use MyCLabs\Enum\Enum;
  */
 final class TableProperty extends Enum
 {
-    private const CHARSET   = 'charset';
-    private const COLLATION = 'collation';
-    private const ENGINE    = 'engine';
+    public const CHARSET   = 'charset';
+    public const COLLATION = 'collation';
+    public const ENGINE    = 'engine';
 }


### PR DESCRIPTION
Hi thanks for bringing this package up to date 🙏 

I wanted to filter some indexes using the Enum variable for IndexType (eg `IndexType::primary`) but noticed that these modifiers were all set to private, which means they are only accessible in their own namespace.

These are constant anyway, so I figured it would make sense to make all of these `Enum`s public.

Having these public would make me allow to filter the primary keys on a table like such:

```
$primaryKeys = $table->getIndexes()->filter(function($index) {
    return $index->getType() == IndexType::PRIMARY;
});
```