### PR TITLE
feat: support database name prefix for cross-database foreign keys

### DIFF
--- a/src/Database/Models/DatabaseForeignKey.php
+++ b/src/Database/Models/DatabaseForeignKey.php
@@ -23,6 +23,7 @@ abstract class DatabaseForeignKey implements ForeignKey
      */
     protected array $foreignColumns;
 
+    protected ?string $foreignSchema = null;
     protected string $foreignTableName;
 
     protected ?string $onUpdate = null;
@@ -37,6 +38,7 @@ abstract class DatabaseForeignKey implements ForeignKey
         $this->tableName        = $table;
         $this->name             = $foreignKey['name'];
         $this->localColumns     = $foreignKey['columns'];
+        $this->foreignSchema    = $foreignKey['foreign_schema'];
         $this->foreignColumns   = $foreignKey['foreign_columns'];
         $this->foreignTableName = $foreignKey['foreign_table'];
         $this->onUpdate         = $foreignKey['on_update'];
@@ -73,6 +75,11 @@ abstract class DatabaseForeignKey implements ForeignKey
     public function getForeignColumns(): array
     {
         return $this->foreignColumns;
+    }
+
+    public function getForeignSchema(): ?string
+    {
+        return $this->foreignSchema;
     }
 
     /**

--- a/src/MigrateGenerateCommand.php
+++ b/src/MigrateGenerateCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema as SchemaFacade;
 use KitLoong\MigrationsGenerator\Enum\Driver;
 use KitLoong\MigrationsGenerator\Migration\ForeignKeyMigration;
 use KitLoong\MigrationsGenerator\Migration\Migrator\Migrator;
@@ -23,9 +24,12 @@ use KitLoong\MigrationsGenerator\Schema\PgSQLSchema;
 use KitLoong\MigrationsGenerator\Schema\Schema;
 use KitLoong\MigrationsGenerator\Schema\SQLiteSchema;
 use KitLoong\MigrationsGenerator\Schema\SQLSrvSchema;
+use KitLoong\MigrationsGenerator\Support\CheckLaravelVersion;
 
 class MigrateGenerateCommand extends Command
 {
+    use CheckLaravelVersion;
+
     /**
      * @inheritDoc
      */
@@ -141,6 +145,13 @@ class MigrateGenerateCommand extends Command
         $setting->setIgnoreForeignKeyNames((bool) $this->option('default-fk-names'));
         $setting->setSquash((bool) $this->option('squash'));
         $setting->setWithHasTable((bool) $this->option('with-has-table'));
+
+        $targetConnection = $this->option('connection') ?: $connection;
+        $setting->setCurrentSchema(
+            $this->atLeastLaravel12()
+                ? SchemaFacade::connection($targetConnection)->getCurrentSchemaName()
+                : null,
+        );
 
         $setting->setPath(
             $this->option('path') ?? Config::get('migrations-generator.migration_target_path'),

--- a/src/Migration/Generator/ForeignKeyGenerator.php
+++ b/src/Migration/Generator/ForeignKeyGenerator.php
@@ -2,7 +2,6 @@
 
 namespace KitLoong\MigrationsGenerator\Migration\Generator;
 
-use Illuminate\Support\Facades\Schema;
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\Foreign;
 use KitLoong\MigrationsGenerator\Migration\Blueprint\Method;
 use KitLoong\MigrationsGenerator\Schema\Models\ForeignKey;
@@ -87,14 +86,15 @@ class ForeignKeyGenerator
 
     /**
      * Get the table name for the foreign key "on" clause.
-     * Adds the database name prefix if it is a cross-database foreign key.
+     * Adds the schema name prefix if it is a cross-schema foreign key.
      */
     private function getOnTableName(ForeignKey $foreignKey): string
     {
-        $table = $this->stripTablePrefix($foreignKey->getForeignTableName());
+        $table         = $this->stripTablePrefix($foreignKey->getForeignTableName());
+        $localSchema   = app(Setting::class)->getCurrentSchema();
         $foreignSchema = $foreignKey->getForeignSchema();
 
-        if ($foreignSchema && $foreignSchema !== Schema::getConnection()->getDatabaseName()) {
+        if ($foreignSchema && $localSchema && $foreignSchema !== $localSchema) {
             return sprintf('%s.%s', $foreignSchema, $table);
         }
 

--- a/src/Migration/Generator/ForeignKeyGenerator.php
+++ b/src/Migration/Generator/ForeignKeyGenerator.php
@@ -2,6 +2,7 @@
 
 namespace KitLoong\MigrationsGenerator\Migration\Generator;
 
+use Illuminate\Support\Facades\Schema;
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\Foreign;
 use KitLoong\MigrationsGenerator\Migration\Blueprint\Method;
 use KitLoong\MigrationsGenerator\Schema\Models\ForeignKey;
@@ -20,7 +21,7 @@ class ForeignKeyGenerator
         $method = $this->makeMethod($foreignKey);
 
         $method->chain(Foreign::REFERENCES, $foreignKey->getForeignColumns())
-            ->chain(Foreign::ON, $this->stripTablePrefix($foreignKey->getForeignTableName()));
+            ->chain(Foreign::ON, $this->getOnTableName($foreignKey));
 
         if ($foreignKey->getOnUpdate() !== null) {
             $method->chain(Foreign::ON_UPDATE, $foreignKey->getOnUpdate());
@@ -82,5 +83,21 @@ class ForeignKeyGenerator
             $foreignKey->getTableName() . '_' . implode('_', $foreignKey->getLocalColumns()) . '_foreign',
         );
         return str_replace(['-', '.'], '_', $name);
+    }
+
+    /**
+     * Get the table name for the foreign key "on" clause.
+     * Adds the database name prefix if it is a cross-database foreign key.
+     */
+    private function getOnTableName(ForeignKey $foreignKey): string
+    {
+        $table = $this->stripTablePrefix($foreignKey->getForeignTableName());
+        $foreignSchema = $foreignKey->getForeignSchema();
+
+        if ($foreignSchema && $foreignSchema !== Schema::getConnection()->getDatabaseName()) {
+            return sprintf('%s.%s', $foreignSchema, $table);
+        }
+
+        return $table;
     }
 }

--- a/src/Schema/Models/ForeignKey.php
+++ b/src/Schema/Models/ForeignKey.php
@@ -21,6 +21,8 @@ interface ForeignKey extends Model
      */
     public function getLocalColumns(): array;
 
+    public function getForeignSchema(): ?string;
+
     /**
      * Get the foreign key foreign column names.
      *

--- a/src/Setting.php
+++ b/src/Setting.php
@@ -12,6 +12,7 @@ class Setting
      */
     private string $defaultConnection;
 
+    private ?string $currentSchema;
     private bool $useDBCollation;
 
     private bool $ignoreIndexNames;
@@ -169,5 +170,15 @@ class Setting
     public function setWithHasTable(bool $withHasTable): void
     {
         $this->withHasTable = $withHasTable;
+    }
+
+    public function setCurrentSchema(?string $currentSchema): void
+    {
+        $this->currentSchema = $currentSchema;
+    }
+
+    public function getCurrentSchema(): ?string
+    {
+        return $this->currentSchema;
     }
 }

--- a/tests/Unit/Migration/Generator/ForeignKeyGeneratorTest.php
+++ b/tests/Unit/Migration/Generator/ForeignKeyGeneratorTest.php
@@ -4,12 +4,17 @@ namespace KitLoong\MigrationsGenerator\Tests\Unit\Migration\Generator;
 
 use KitLoong\MigrationsGenerator\Database\Models\SQLite\SQLiteForeignKey;
 use KitLoong\MigrationsGenerator\Enum\Migrations\Method\Foreign;
+use KitLoong\MigrationsGenerator\Migration\Blueprint\Method;
 use KitLoong\MigrationsGenerator\Migration\Generator\ForeignKeyGenerator;
 use KitLoong\MigrationsGenerator\Setting;
+use KitLoong\MigrationsGenerator\Support\CheckLaravelVersion;
 use KitLoong\MigrationsGenerator\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ForeignKeyGeneratorTest extends TestCase
 {
+    use CheckLaravelVersion;
+
     public function testGenerateDropWithNullName(): void
     {
         $setting = app(Setting::class);
@@ -29,5 +34,44 @@ class ForeignKeyGeneratorTest extends TestCase
 
         $this->assertSame($method->getName(), Foreign::DROP_FOREIGN);
         $this->assertEmpty($method->getValues());
+    }
+
+    #[DataProvider('schemaDataProvider')]
+    public function testGenerateOnTableName(?string $currentSchema, ?string $foreignSchema, string $expectedOnValue): void
+    {
+        $setting = app(Setting::class);
+        $setting->setIgnoreForeignKeyNames(false);
+        $setting->setCurrentSchema($currentSchema);
+
+        $foreignKey = new SQLiteForeignKey('table', [
+            'name'            => null,
+            'columns'         => ['column'],
+            'foreign_schema'  => $foreignSchema,
+            'foreign_table'   => 'foreign_table',
+            'foreign_columns' => ['foreign_column'],
+            'on_update'       => 'on_update',
+            'on_delete'       => 'on_delete',
+        ]);
+
+        $method = app(ForeignKeyGenerator::class)->generate($foreignKey);
+
+        $onChain = collect($method->getChains())->first(static fn ($chain) => $chain->getName() === Foreign::ON);
+
+        $this->assertInstanceOf(Method::class, $onChain);
+        $this->assertSame([$expectedOnValue], $onChain->getValues());
+    }
+
+    /**
+     * @return array<string, array{0: string|null, 1: string|null, 2: string}>
+     */
+    public static function schemaDataProvider(): array
+    {
+        return [
+            'both schema null'           => [null, null, 'foreign_table'],
+            'only current schema exists' => ['public', null, 'foreign_table'],
+            'only foreign schema exists' => [null, 'other_schema', 'foreign_table'],
+            'same schema'                => ['public', 'public', 'foreign_table'],
+            'different schema'           => ['public', 'other_schema', 'other_schema.foreign_table'],
+        ];
     }
 }


### PR DESCRIPTION
### Description
When generating migrations for tables that have foreign keys pointing to a different database/schema (cross-database references), the schema name was previously omitted in the `on()` clause. This resulted in generated migrations like `->on('table_name')` instead of the required `->on('schema_name.table_name')`.

This PR introduces a check to safely append the schema/database name prefix to the `on()` clause **only** when the target foreign schema differs from the current active connection schema.

### Changes
To implement this without breaking existing interfaces or causing N+1 query issues, I utilized the existing `Setting` singleton:
- **`src/Setting.php`**: Added a `$currentSchema` property to globally track the active schema of the target connection during generation.
- **`src/MigrateGenerateCommand.php`**: Resolved the target connection early in the `setup()` phase and populated `$currentSchema` using `SchemaFacade::connection($targetConnection)->getCurrentSchemaName()` (safely falling back to `null` for Laravel 11 and below to prevent uninitialized property errors).
- **`src/Migration/Generator/ForeignKeyGenerator.php`**: Updated the foreign key generation logic to compare the local schema (from `Setting`) against the target `$foreignSchema`. The prefix is strictly appended only when both are present and they do not match.

### Testing
- **Unit Tests**: Completely refactored `ForeignKeyGeneratorTest@testGenerateOnTableName` to use a `DataProvider` (`schemaDataProvider`). This exhaustively tests all boundary conditions (both null, only current exists, only foreign exists, same schema, different schema) using mock DTOs instead of relying on actual DB connections, significantly improving test stability and decoupling.